### PR TITLE
[Don't merge plz] Question about how to use ob-verific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ __pycache__
 /tests/unit/objtest/
 /tests/ystests
 /build
+
+maple

--- a/Makefile
+++ b/Makefile
@@ -510,13 +510,14 @@ endif
 endif
 
 ifeq ($(ENABLE_VERIFIC),1)
-VERIFIC_DIR ?= /home/andy/icbench/maple/verific
+VERIFIC_DIR ?= maple/src/verific
+VERIFIC_LIB ?= maple/build/src/verific
 VERIFIC_COMPONENTS ?= verilog  database util containers commands verilog_nl 
 CXXFLAGS += $(patsubst %,-I$(VERIFIC_DIR)/%,$(VERIFIC_COMPONENTS)) -DYOSYS_ENABLE_VERIFIC
 ifeq ($(OS), Darwin)
 LDLIBS += $(patsubst %,$(VERIFIC_DIR)/%/*-mac.a,$(VERIFIC_COMPONENTS)) -lz
 else
-LDLIBS += $(patsubst %,$(VERIFIC_DIR)/%/*-linux.a,$(VERIFIC_COMPONENTS)) -lz
+LDLIBS += $(patsubst %,$(VERIFIC_LIB)/%/*.a,$(VERIFIC_COMPONENTS)) -lz
 endif
 endif
 

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-export VERIFIC_DIR = /home/andy/icbench/maple/verific
-make PREFIX=build CONFIG=gcc install -j$(nproc)
+git clone --recursive git@github.com:ICBench/maple.git
+cd maple && ./etc/Build.sh
+cd ..
+make PREFIX=build CONFIG=gcc VERIFIC_DIR=maple/src/verific VERIFIC_LIB=maple/build/src/verific install -j$(nproc)


### PR DESCRIPTION
Sorry for bothering you, Andy. 
Yosys does not allow new issues to be created, so I need to create a pr to ask for some advice from you.

I pulled your fork and cloned maple as source code of verific.
I hack some environment variable to make yosys with ob-verific.
But after I successfully made them, I found that I don’t know how to use ob-verific to read the system verilog file.
The `read` cmd doesn't seem to work, and I can't read a tcl script by using `-script_file` argument.
I'm sorry, but could you teach me how to use ov-verific in yosys?
Is there any argument that I forgot?

Bonne journée
